### PR TITLE
CI/DOC: Fix CI for documentation generation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,6 +30,10 @@ jobs:
         use-mamba: true
         miniforge-variant: Mambaforge
 
+    - name: install dependencies
+      run: |
+        python -m pip install --no-deps .
+
     # Build the book
     - name: Build the book
       run: |


### PR DESCRIPTION
Currently, the documentation is not processed correctly because sqlalchemy-omnisci is not installed in environment on CI documentation.